### PR TITLE
Add venv creation and activation support

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -59,9 +59,4 @@ jobs:
         run: |
           which python
       - name: check inside virtual environment
-        run: |
-          echo $(python <<EOF
-          import sys
-          print('Yes' if sys.prefix != sys.base_prefix else 'No')
-          EOF
-          )
+        run: python -c "import sys; print('Yes' if sys.prefix != sys.base_prefix else 'No')"

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -8,8 +8,8 @@ jobs:
   lint-and-test-units:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         id: npm-cache
         with:
           path: ~/.npm

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -41,8 +41,8 @@ jobs:
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - uses: ./

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -2,8 +2,6 @@ name: default
 on:
   pull_request:
   push:
-    branches:
-      - main
 
 jobs:
   # run linters and unit tests
@@ -50,4 +48,13 @@ jobs:
       - uses: ./
         with:
           uv-version: ${{ matrix.uv-version }}
+          uv-venv: "my_virt_env"
       - run: uv --version
+      - name: List files
+        if: runner.os == 'Windows'
+        run: |
+          Get-ChildItem -Force -Path my_virt_env
+      - name: List files
+        if: runner.os != 'Windows'
+        run: |
+          ls -la my_virt_env

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -50,11 +50,11 @@ jobs:
           uv-version: ${{ matrix.uv-version }}
           uv-venv: "my_virt_env"
       - run: uv --version
-      - name: List files
+      - name: Get python executable
         if: runner.os == 'Windows'
         run: |
-          Get-ChildItem -Force -Path my_virt_env
-      - name: List files
+          where python
+      - name: Get python executable
         if: runner.os != 'Windows'
         run: |
-          ls -la my_virt_env
+          which python

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -48,7 +48,6 @@ jobs:
       - uses: ./
         with:
           uv-version: ${{ matrix.uv-version }}
-          uv-venv: "my_virt_env"
       - run: uv --version
       - name: Get python executable
         if: runner.os == 'Windows'

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -48,6 +48,7 @@ jobs:
       - uses: ./
         with:
           uv-version: ${{ matrix.uv-version }}
+          uv-venv: "my_virt_env"
       - run: uv --version
       - name: Get python executable on Windows
         if: runner.os == 'Windows'

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -53,8 +53,15 @@ jobs:
       - name: Get python executable
         if: runner.os == 'Windows'
         run: |
-          where python
+          Get-Command python
       - name: Get python executable
         if: runner.os != 'Windows'
         run: |
           which python
+      - name: check inside virtual environment
+        run: |
+          echo $(python <<EOF
+          import sys
+          print('Yes' if sys.prefix != sys.base_prefix else 'No')
+          EOF
+          )

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -49,13 +49,13 @@ jobs:
         with:
           uv-version: ${{ matrix.uv-version }}
       - run: uv --version
-      - name: Get python executable
+      - name: Get python executable on Windows
         if: runner.os == 'Windows'
         run: |
           Get-Command python
-      - name: Get python executable
+      - name: Get python executable on non-Windows
         if: runner.os != 'Windows'
         run: |
           which python
-      - name: check inside virtual environment
-        run: python -c "import sys; print('Yes' if sys.prefix != sys.base_prefix else 'No')"
+      - name: Check inside virtual environment
+        run: python -c "import sys; exit(0 if sys.prefix != sys.base_prefix else 1)"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ steps:
   - uses: yezz123/setup-uv@v1
     with:
       uv-preview: true
-  - run: uv pip install black # this command will run in the uv environment
+  - run: uv --version
 ```
 
 ### Create and activate a virtual environment using uv
@@ -62,7 +62,7 @@ steps:
   - uses: yezz123/setup-uv@v1
     with:
       uv-venv: "your_venv_name"
-  - run: uv --version
+  - run: uv pip install black # this command will run in the uv environment
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ steps:
   - uses: yezz123/setup-uv@v1
     with:
       uv-preview: true
+  - run: uv pip install black # this command will run in the uv environment
+```
+
+### Create and activate a virtual environment using uv
+
+```yaml
+steps:
+  - uses: actions/checkout@v3
+  - uses: actions/setup-python@v4
+    with:
+      python-version: "3.11"
+  - uses: yezz123/setup-uv@v1
+    with:
+      uv-venv: "your_venv_name"
   - run: uv --version
 ```
 

--- a/__tests__/input.test.ts
+++ b/__tests__/input.test.ts
@@ -1,4 +1,10 @@
-import { getBooleanInput, getInputs, getVersionInput } from '../src/inputs'
+import { getInput } from '@actions/core'
+import {
+  getBooleanInput,
+  getInputs,
+  getVenvInput,
+  getVersionInput
+} from '../src/inputs'
 
 const TEST_ENV_VARS = {
   INPUT_MISSING: '',
@@ -9,7 +15,8 @@ const TEST_ENV_VARS = {
   INPUT_VERSION_ALPHA: '0.1.3.0a1',
 
   'INPUT_UV-PREVIEW': 'true',
-  'INPUT_UV-VERSION': '0.1.2'
+  'INPUT_UV-VERSION': '0.1.2',
+  'INPUT_UV-VENV': 'my_venv'
 }
 
 describe('options', () => {
@@ -42,7 +49,11 @@ describe('options', () => {
   })
 
   it('getInputs returns inputs', () => {
-    expect(getInputs()).toStrictEqual({ preview: true, version: '0.1.2' })
+    expect(getInputs()).toStrictEqual({
+      preview: true,
+      version: '0.1.2',
+      venv: 'my_venv'
+    })
   })
 
   it('getVersionInput throws if input is not valid', () => {
@@ -57,5 +68,13 @@ describe('options', () => {
 
   it('getVersionInput returns version if input is alpha', () => {
     expect(getVersionInput('version_alpha')).toBe('0.1.3.0a1')
+  })
+
+  it('getVenvInput returns venv name if input is valid', () => {
+    expect(getVenvInput('uv-venv')).toBe('my_venv')
+  })
+
+  it('getVenvInput returns .venv if input is not provided', () => {
+    expect(getVenvInput('SOMETHING')).toBe('.venv')
   })
 })

--- a/__tests__/input.test.ts
+++ b/__tests__/input.test.ts
@@ -74,7 +74,7 @@ describe('options', () => {
     expect(getVenvInput('uv-venv')).toBe('my_venv')
   })
 
-  it('getVenvInput returns .venv if input is not provided', () => {
-    expect(getVenvInput('SOMETHING')).toBe('.venv')
+  it('getVenvInput returns null if input is not provided', () => {
+    expect(getVenvInput('SOMETHING')).toBeNull()
   })
 })

--- a/action.yml
+++ b/action.yml
@@ -10,9 +10,8 @@ inputs:
     description: uv version to use, if version is not provided then latest stable version will be used
     required: false
   uv-venv:
-    description: uv venv name to create and activate, if not provided then .venv will be used
+    description: virtual environment name to create and activate.
     required: false
-    default: '.venv'
 runs:
   using: node20
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
   uv-version:
     description: uv version to use, if version is not provided then latest stable version will be used
     required: false
+  uv-venv:
+    description: uv venv name to create, if not provided then .venv will be used
+    required: false
+    default: '.venv'
 runs:
   using: node20
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: uv version to use, if version is not provided then latest stable version will be used
     required: false
   uv-venv:
-    description: uv venv name to create, if not provided then .venv will be used
+    description: uv venv name to create and activate, if not provided then .venv will be used
     required: false
     default: '.venv'
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -31906,13 +31906,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getVersionInput = exports.getBooleanInput = exports.getInputs = void 0;
+exports.getVenvInput = exports.getVersionInput = exports.getBooleanInput = exports.getInputs = void 0;
 const core_1 = __nccwpck_require__(2186);
 const semver_1 = __importDefault(__nccwpck_require__(1383));
 function getInputs() {
     return {
         preview: getBooleanInput('uv-preview'),
-        version: getVersionInput('uv-version')
+        version: getVersionInput('uv-version'),
+        venv: getVenvInput('uv-venv')
     };
 }
 exports.getInputs = getInputs;
@@ -31940,6 +31941,43 @@ function getVersionInput(name) {
     return version.trim();
 }
 exports.getVersionInput = getVersionInput;
+function getVenvInput(name, default_ = '.venv') {
+    const venv = (0, core_1.getInput)(name);
+    if (!venv) {
+        return default_;
+    }
+    return venv.trim();
+}
+exports.getVenvInput = getVenvInput;
+
+
+/***/ }),
+
+/***/ 667:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.activateVenv = exports.createVenv = void 0;
+const exec_1 = __nccwpck_require__(1514);
+const os_1 = __importDefault(__nccwpck_require__(2037));
+async function createVenv(venv) {
+    await (0, exec_1.exec)('uv', ['venv', venv]);
+}
+exports.createVenv = createVenv;
+async function activateVenv(venv) {
+    if (os_1.default.platform() === 'win32') {
+        await (0, exec_1.exec)('powershell', [`${venv}\\Scripts\\activate.ps1`]);
+    }
+    else {
+        await (0, exec_1.exec)('sh', [`source ${venv}/bin/activate`]);
+    }
+}
+exports.activateVenv = activateVenv;
 
 
 /***/ }),
@@ -33851,10 +33889,15 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core_1 = __nccwpck_require__(2186);
 const find_1 = __nccwpck_require__(3288);
 const inputs_1 = __nccwpck_require__(7063);
+const venv_1 = __nccwpck_require__(667);
 async function run() {
     try {
         const inputs = (0, inputs_1.getInputs)();
         await (0, find_1.findUv)(inputs);
+        if (inputs.venv) {
+            await (0, venv_1.createVenv)(inputs.venv);
+            await (0, venv_1.activateVenv)(inputs.venv);
+        }
     }
     catch (error) {
         (0, core_1.setFailed)(errorAsMessage(error));

--- a/dist/index.js
+++ b/dist/index.js
@@ -31972,7 +31972,7 @@ async function createVenv(venv) {
 exports.createVenv = createVenv;
 async function activateVenv(venv) {
     if (os_1.default.platform() === 'win32') {
-        await (0, exec_1.exec)(`${venv}/Scripts/activate.ps1`);
+        await (0, exec_1.exec)('powershell', [`${venv}\\Scripts\\activate.ps1`]);
         (0, core_1.addPath)(`${venv}/Scripts`);
     }
     else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -31974,7 +31974,7 @@ async function activateVenv(venv) {
         await (0, exec_1.exec)('powershell', [`${venv}\\Scripts\\activate.ps1`]);
     }
     else {
-        await (0, exec_1.exec)('sh', [`source ${venv}/bin/activate`]);
+        await (0, exec_1.exec)('source', [`${venv}/bin/activate`]);
     }
 }
 exports.activateVenv = activateVenv;

--- a/dist/index.js
+++ b/dist/index.js
@@ -31972,7 +31972,7 @@ async function createVenv(venv) {
 exports.createVenv = createVenv;
 async function activateVenv(venv) {
     if (os_1.default.platform() === 'win32') {
-        await (0, exec_1.exec)('powershell', [`${venv}\\Scripts\\activate.ps1`]);
+        await (0, exec_1.exec)(`${venv}\\Scripts\\activate.ps1`);
     }
     else {
         await (0, exec_1.exec)('/bin/bash', ['-c', `source ${venv}/bin/activate`]);

--- a/dist/index.js
+++ b/dist/index.js
@@ -31972,7 +31972,7 @@ async function createVenv(venv) {
 exports.createVenv = createVenv;
 async function activateVenv(venv) {
     if (os_1.default.platform() === 'win32') {
-        await (0, exec_1.exec)(`${venv}\\Scripts\\activate.ps1`);
+        await (0, exec_1.exec)(`${venv}/Scripts/activate.ps1`);
     }
     else {
         await (0, exec_1.exec)('/bin/bash', ['-c', `source ${venv}/bin/activate`]);

--- a/dist/index.js
+++ b/dist/index.js
@@ -31974,7 +31974,7 @@ async function activateVenv(venv) {
         await (0, exec_1.exec)('powershell', [`${venv}\\Scripts\\activate.ps1`]);
     }
     else {
-        await (0, exec_1.exec)(`. ${venv}/bin/activate`);
+        await (0, exec_1.exec)('source', [`${venv}/bin/activate`]);
     }
 }
 exports.activateVenv = activateVenv;
@@ -33890,12 +33890,15 @@ const core_1 = __nccwpck_require__(2186);
 const find_1 = __nccwpck_require__(3288);
 const inputs_1 = __nccwpck_require__(7063);
 const venv_1 = __nccwpck_require__(667);
+const exec_1 = __nccwpck_require__(1514);
 async function run() {
     try {
         const inputs = (0, inputs_1.getInputs)();
         await (0, find_1.findUv)(inputs);
         if (inputs.venv) {
             await (0, venv_1.createVenv)(inputs.venv);
+            // Debugging only
+            await (0, exec_1.exec)(`ls -lR ${inputs.venv}`);
             await (0, venv_1.activateVenv)(inputs.venv);
         }
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -31974,7 +31974,7 @@ async function activateVenv(venv) {
         await (0, exec_1.exec)('powershell', [`${venv}\\Scripts\\activate.ps1`]);
     }
     else {
-        await (0, exec_1.exec)('source', [`${venv}/bin/activate`]);
+        await (0, exec_1.exec)(`. ${venv}/bin/activate`);
     }
 }
 exports.activateVenv = activateVenv;

--- a/dist/index.js
+++ b/dist/index.js
@@ -31973,12 +31973,13 @@ exports.createVenv = createVenv;
 async function activateVenv(venv) {
     if (os_1.default.platform() === 'win32') {
         await (0, exec_1.exec)(`${venv}/Scripts/activate.ps1`);
+        (0, core_1.addPath)(`${venv}/Scripts`);
     }
     else {
         await (0, exec_1.exec)('/bin/bash', ['-c', `source ${venv}/bin/activate`]);
+        (0, core_1.addPath)(`${venv}/bin`);
     }
     (0, core_1.exportVariable)('VIRTUAL_ENV', venv);
-    (0, core_1.addPath)(`${venv}/bin`);
 }
 exports.activateVenv = activateVenv;
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -31974,7 +31974,7 @@ async function activateVenv(venv) {
         await (0, exec_1.exec)('powershell', [`${venv}\\Scripts\\activate.ps1`]);
     }
     else {
-        await (0, exec_1.exec)('source', [`${venv}/bin/activate`]);
+        await (0, exec_1.exec)(`source ${venv}/bin/activate`);
     }
 }
 exports.activateVenv = activateVenv;

--- a/dist/index.js
+++ b/dist/index.js
@@ -31941,10 +31941,10 @@ function getVersionInput(name) {
     return version.trim();
 }
 exports.getVersionInput = getVersionInput;
-function getVenvInput(name, default_ = '.venv') {
+function getVenvInput(name) {
     const venv = (0, core_1.getInput)(name);
     if (!venv) {
-        return default_;
+        return null;
     }
     return venv.trim();
 }
@@ -33894,15 +33894,12 @@ const core_1 = __nccwpck_require__(2186);
 const find_1 = __nccwpck_require__(3288);
 const inputs_1 = __nccwpck_require__(7063);
 const venv_1 = __nccwpck_require__(667);
-const exec_1 = __nccwpck_require__(1514);
 async function run() {
     try {
         const inputs = (0, inputs_1.getInputs)();
         await (0, find_1.findUv)(inputs);
         if (inputs.venv) {
             await (0, venv_1.createVenv)(inputs.venv);
-            // Debugging only
-            await (0, exec_1.exec)(`ls -lR ${inputs.venv}`);
             await (0, venv_1.activateVenv)(inputs.venv);
         }
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -31964,6 +31964,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.activateVenv = exports.createVenv = void 0;
 const exec_1 = __nccwpck_require__(1514);
+const core_1 = __nccwpck_require__(2186);
 const os_1 = __importDefault(__nccwpck_require__(2037));
 async function createVenv(venv) {
     await (0, exec_1.exec)('uv', ['venv', venv]);
@@ -31976,6 +31977,8 @@ async function activateVenv(venv) {
     else {
         await (0, exec_1.exec)('/bin/bash', ['-c', `source ${venv}/bin/activate`]);
     }
+    (0, core_1.exportVariable)('VIRTUAL_ENV', venv);
+    (0, core_1.addPath)(`${venv}/bin`);
 }
 exports.activateVenv = activateVenv;
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -31974,7 +31974,7 @@ async function activateVenv(venv) {
         await (0, exec_1.exec)('powershell', [`${venv}\\Scripts\\activate.ps1`]);
     }
     else {
-        await (0, exec_1.exec)(`source ${venv}/bin/activate`);
+        await (0, exec_1.exec)('/bin/bash', ['-c', `source ${venv}/bin/activate`]);
     }
 }
 exports.activateVenv = activateVenv;

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -1,16 +1,17 @@
 import { getInput } from '@actions/core'
 import semver from 'semver'
-
 export interface Inputs {
   // Finder related inputs
   preview: boolean
   version: string | null
+  venv: string | null
 }
 
 export function getInputs(): Inputs {
   return {
     preview: getBooleanInput('uv-preview'),
-    version: getVersionInput('uv-version')
+    version: getVersionInput('uv-version'),
+    venv: getVenvInput('uv-venv')
   }
 }
 
@@ -40,4 +41,12 @@ export function getVersionInput(name: string): string | null {
   }
 
   return version.trim()
+}
+
+export function getVenvInput(name: string, default_ = '.venv'): string {
+  const venv = getInput(name)
+  if (!venv) {
+    return default_
+  }
+  return venv.trim()
 }

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -43,10 +43,10 @@ export function getVersionInput(name: string): string | null {
   return version.trim()
 }
 
-export function getVenvInput(name: string, default_ = '.venv'): string {
+export function getVenvInput(name: string): string | null {
   const venv = getInput(name)
   if (!venv) {
-    return default_
+    return null
   }
   return venv.trim()
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,17 @@
 import { setFailed } from '@actions/core'
 import { findUv } from './find'
 import { getInputs } from './inputs'
+import { activateVenv, createVenv } from './venv'
 
 async function run(): Promise<void> {
   try {
     const inputs = getInputs()
 
     await findUv(inputs)
+    if (inputs.venv) {
+      await createVenv(inputs.venv)
+      await activateVenv(inputs.venv)
+    }
   } catch (error) {
     setFailed(errorAsMessage(error))
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { setFailed } from '@actions/core'
 import { findUv } from './find'
 import { getInputs } from './inputs'
 import { activateVenv, createVenv } from './venv'
-
+import { exec } from '@actions/exec'
 async function run(): Promise<void> {
   try {
     const inputs = getInputs()
@@ -10,6 +10,8 @@ async function run(): Promise<void> {
     await findUv(inputs)
     if (inputs.venv) {
       await createVenv(inputs.venv)
+      // Debugging only
+      await exec(`ls -lR ${inputs.venv}`)
       await activateVenv(inputs.venv)
     }
   } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,8 +10,6 @@ async function run(): Promise<void> {
     await findUv(inputs)
     if (inputs.venv) {
       await createVenv(inputs.venv)
-      // Debugging only
-      await exec(`ls -lR ${inputs.venv}`)
       await activateVenv(inputs.venv)
     }
   } catch (error) {

--- a/src/venv.ts
+++ b/src/venv.ts
@@ -9,9 +9,10 @@ export async function createVenv(venv: string) {
 export async function activateVenv(venv: string) {
   if (os.platform() === 'win32') {
     await exec(`${venv}/Scripts/activate.ps1`)
+    addPath(`${venv}/Scripts`)
   } else {
     await exec('/bin/bash', ['-c', `source ${venv}/bin/activate`])
+    addPath(`${venv}/bin`)
   }
   exportVariable('VIRTUAL_ENV', venv)
-  addPath(`${venv}/bin`)
 }

--- a/src/venv.ts
+++ b/src/venv.ts
@@ -8,7 +8,7 @@ export async function createVenv(venv: string) {
 
 export async function activateVenv(venv: string) {
   if (os.platform() === 'win32') {
-    await exec('powershell', [`${venv}\\Scripts\\activate.ps1`])
+    await exec(`${venv}\\Scripts\\activate.ps1`)
   } else {
     await exec('/bin/bash', ['-c', `source ${venv}/bin/activate`])
   }

--- a/src/venv.ts
+++ b/src/venv.ts
@@ -8,7 +8,7 @@ export async function createVenv(venv: string) {
 
 export async function activateVenv(venv: string) {
   if (os.platform() === 'win32') {
-    await exec(`${venv}/Scripts/activate.ps1`)
+    await exec('powershell', [`${venv}\\Scripts\\activate.ps1`])
     addPath(`${venv}/Scripts`)
   } else {
     await exec('/bin/bash', ['-c', `source ${venv}/bin/activate`])

--- a/src/venv.ts
+++ b/src/venv.ts
@@ -8,7 +8,7 @@ export async function createVenv(venv: string) {
 
 export async function activateVenv(venv: string) {
   if (os.platform() === 'win32') {
-    await exec(`${venv}\\Scripts\\activate.ps1`)
+    await exec(`${venv}/Scripts/activate.ps1`)
   } else {
     await exec('/bin/bash', ['-c', `source ${venv}/bin/activate`])
   }

--- a/src/venv.ts
+++ b/src/venv.ts
@@ -9,6 +9,6 @@ export async function activateVenv(venv: string) {
   if (os.platform() === 'win32') {
     await exec('powershell', [`${venv}\\Scripts\\activate.ps1`])
   } else {
-    await exec('source', [`${venv}/bin/activate`])
+    await exec(`source ${venv}/bin/activate`)
   }
 }

--- a/src/venv.ts
+++ b/src/venv.ts
@@ -9,6 +9,6 @@ export async function activateVenv(venv: string) {
   if (os.platform() === 'win32') {
     await exec('powershell', [`${venv}\\Scripts\\activate.ps1`])
   } else {
-    await exec(`source ${venv}/bin/activate`)
+    await exec('/bin/bash', ['-c', `source ${venv}/bin/activate`])
   }
 }

--- a/src/venv.ts
+++ b/src/venv.ts
@@ -1,4 +1,5 @@
 import { exec } from '@actions/exec'
+import { exportVariable, addPath } from '@actions/core'
 import os from 'os'
 
 export async function createVenv(venv: string) {
@@ -11,4 +12,6 @@ export async function activateVenv(venv: string) {
   } else {
     await exec('/bin/bash', ['-c', `source ${venv}/bin/activate`])
   }
+  exportVariable('VIRTUAL_ENV', venv)
+  addPath(`${venv}/bin`)
 }

--- a/src/venv.ts
+++ b/src/venv.ts
@@ -9,6 +9,6 @@ export async function activateVenv(venv: string) {
   if (os.platform() === 'win32') {
     await exec('powershell', [`${venv}\\Scripts\\activate.ps1`])
   } else {
-    await exec(`. ${venv}/bin/activate`)
+    await exec('source', [`${venv}/bin/activate`])
   }
 }

--- a/src/venv.ts
+++ b/src/venv.ts
@@ -9,6 +9,6 @@ export async function activateVenv(venv: string) {
   if (os.platform() === 'win32') {
     await exec('powershell', [`${venv}\\Scripts\\activate.ps1`])
   } else {
-    await exec('source', [`${venv}/bin/activate`])
+    await exec(`. ${venv}/bin/activate`)
   }
 }

--- a/src/venv.ts
+++ b/src/venv.ts
@@ -1,0 +1,14 @@
+import { exec } from '@actions/exec'
+import os from 'os'
+
+export async function createVenv(venv: string) {
+  await exec('uv', ['venv', venv])
+}
+
+export async function activateVenv(venv: string) {
+  if (os.platform() === 'win32') {
+    await exec('powershell', [`${venv}\\Scripts\\activate.ps1`])
+  } else {
+    await exec('sh', [`source ${venv}/bin/activate`])
+  }
+}

--- a/src/venv.ts
+++ b/src/venv.ts
@@ -9,6 +9,6 @@ export async function activateVenv(venv: string) {
   if (os.platform() === 'win32') {
     await exec('powershell', [`${venv}\\Scripts\\activate.ps1`])
   } else {
-    await exec('sh', [`source ${venv}/bin/activate`])
+    await exec('source', [`${venv}/bin/activate`])
   }
 }


### PR DESCRIPTION
This PR adds the `uv-venv` option to create and activate a virtual environment using `uv`.

Usage:
```yml
steps:
  - uses: actions/checkout@v3
  - uses: actions/setup-python@v4
    with:
      python-version: "3.11"
  - uses: yezz123/setup-uv@v1
    with:
      uv-venv: "your_venv_name"
  - run: uv pip install black # this command will run in the uv environment
```

Solves yezz123/setup-uv#6