### PR TITLE
docs: upgrade version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ steps:
   - uses: actions/setup-python@v4
     with:
       python-version: "3.11"
-  - uses: yezz123/setup-uv@v1
+  - uses: yezz123/setup-uv@v4
   - run: uv --version
 ```
 
@@ -31,7 +31,7 @@ steps:
   - uses: actions/setup-python@v4
     with:
       python-version: "3.11"
-  - uses: yezz123/setup-uv@v1
+  - uses: yezz123/setup-uv@v4
     with:
       uv-version: "0.1.12"
   - run: uv --version
@@ -45,7 +45,7 @@ steps:
   - uses: actions/setup-python@v4
     with:
       python-version: "3.11"
-  - uses: yezz123/setup-uv@v1
+  - uses: yezz123/setup-uv@v4
     with:
       uv-venv: "your_venv_name"
   - run: uv pip install black # this command will run in the uv environment


### PR DESCRIPTION
`uv-venv: "your_venv_name"` was introduced in `@v2` but the README displays using `@v1`. In general, it should be updated to the latest release.

Additional improvements, in the future, might include the mention of the `--system` flag for `uv pip install`. Because `uv` expects a `venv` by default