### PR TITLE
change warning to notice

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31930,7 +31930,7 @@ exports.getInputs = getInputs;
 function getVersionInput(name) {
     const version = (0, core_1.getInput)(name);
     if (!version) {
-        (0, core_1.warning)('Using latest version of uv because no version is provided');
+        (0, core_1.notice)('No uv version specified. Using latest version');
         return null;
     }
     const coerced = semver_1.default.coerce(version);

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -1,4 +1,4 @@
-import { getInput, warning } from '@actions/core'
+import { getInput, notice } from '@actions/core'
 import semver from 'semver'
 export interface Inputs {
   version: string | null
@@ -15,7 +15,7 @@ export function getInputs(): Inputs {
 export function getVersionInput(name: string): string | null {
   const version = getInput(name)
   if (!version) {
-    warning('Using latest version of uv because no version is provided')
+    notice('No uv version specified. Using latest version')
     return null
   }
 


### PR DESCRIPTION
When not specified uv version, annotation should just inform about it.
Potentially will solve https://github.com/yezz123/setup-uv/issues/31

Available annotations on the github actions (https://github.com/actions/toolkit/tree/main/packages/core):

![image](https://github.com/yezz123/setup-uv/assets/9288093/75628925-6319-4fe5-a48a-cc26f45b9664)
